### PR TITLE
DBの設計：README.mdへのDB設計コードの記述

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :messages

--- a/README.md
+++ b/README.md
@@ -22,3 +22,59 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|mail|string|null: false|
+|password|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :groups,  through: :groups_users
+
+
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+
+### Association
+- has_many :messages
+- has_many :users,  through: :groups_users
+
+
+
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+
+
+## messagessテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|group_id|integer|null: false, references :user, foreign_key: true|
-|user_id|integer|null: false, references :group, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -74,8 +74,8 @@ Things you may want to cover:
 |------|----|-------|
 |body|text||
 |image|string||
-|group_id|integer|null: false, references :user, foreign_key: true|
-|user_id|integer|null: false, references :group, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 
 ### Association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, references :user, foreign_key: true|
+|user_id|integer|null: false, references :group,　foreign_key: true|
 
 ### Association
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Things you may want to cover:
 
 ### Association
 - has_many :messages
+- has_many :groups_users
 - has_many :groups,  through: :groups_users
 
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |image|string||
 |group_id|integer|null: false, foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Things you may want to cover:
 
 ### Association
 - has_many :messages
+- has_many :groups_users
 - has_many :users,  through: :groups_users
 
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Things you may want to cover:
 |Column|Type|Options|
 |------|----|-------|
 |group_id|integer|null: false, references :user, foreign_key: true|
-|user_id|integer|null: false, references :group,　foreign_key: true|
+|user_id|integer|null: false, references :group, foreign_key: true|
 
 ### Association
 - belongs_to :group
@@ -74,8 +74,8 @@ Things you may want to cover:
 |------|----|-------|
 |body|text||
 |image|string||
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, references :user, foreign_key: true|
+|user_id|integer|null: false, references :group, foreign_key: true|
 
 ### Association
 - belongs_to :group


### PR DESCRIPTION
#what
ユーザーのchat-space利用時に必要なテーブル名（エンティティ）、カラム項目（属性）、カラムオプションを抽出し、それをマークダウン方式でREADME.mdに記載しました。

#why
chat-spaceの機能を実現するためには、ユーザーの情報、ユーザーが所属するグループ、グループに属するユーザー、投稿内容をDBに保存する必要があります。また、コードを書き始める前に、テーブル名やカラム項目名、それらの関係性とカラムの制約を設定しなければ、行き当たりばったりな開発となり、スムーズな開発が行えないからです。