### PR TITLE
メッセージ履歴エリアのはみ出し部分にCSSを適用し、スクロールできるように。

### DIFF
--- a/app/assets/stylesheets/modules/_messages_main_messages.scss
+++ b/app/assets/stylesheets/modules/_messages_main_messages.scss
@@ -1,4 +1,5 @@
 .messages {
+  overflow: scroll;
   background-color: #FAFAFA;
   box-sizing: border-box;
   padding: 46px 40px 0;


### PR DESCRIPTION
#what
メッセージを複数回投稿すると、メッセージフォームを跨いで表示されるようになってしまった。親要素にoverflow: scroll;を適用し、エリア内に収まる部分だけ表示させ、スクロールで非表示の部分を表示する仕様にした。

#why
メッセージを入力しようとする際に、何を入力したのか見えなくなってしまっていた。これでは、ユーザーはストレスが溜まってしまうので、上に重なるメッセージを隠し、スクロールすることで見えるようになれば良いと考えこのような仕様にしました。