### PR TITLE
グループ編集の際のユーザー表示の修正

### DIFF
--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -55,6 +55,7 @@ $(function() {
       });
   });
   $(document).on("click", ".chat-group-user__btn--add", function() {
+    console.log
     const userName = $(this).attr("data-user-name");
     const userId = $(this).attr("data-user-id");
     $(this)

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -26,9 +26,18 @@
     .chat-group-form__field--right
     
       #chat-group-users.js-add-user
-        .chat-group-user.clearfix.js-chat-member#chat-group-user-8
+        .chat-group-user.clearfix.js-chat-member
           %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
           %p.chat-group-user__name= current_user.name
+
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .chat-group-user.clearfix.js-chat-member
+              %input{name: "group[user_ids][]", type: "hidden", value: user.id}
+              %p.chat-group-user__name
+                = user.name 
+              %a.user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn
+                削除
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left


### PR DESCRIPTION
#what
グループ編集の際に、ユーザーの表示がログインしているユーザーのみであったので、そのグループに属する全てのユーザーを表示できるようにしました。

#why
グループ編集の際は、誰がこのグループに属しているのかを一覧で表示させ、隣に削除ボタンを表示させることで、編集をよりスムーズに行えるようにするためです。