### PR TITLE
メッセージ投稿に関する自動更新の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,44 +1,99 @@
 $(function(){
-  function buildHTML(message){
-    if ( message.image ) {
-      var html =
-       `<div class="message" data-message-id=${message.id}>
-          <div class="upper-message">
-            <div class="upper-message__user-name">
-              ${message.user_name}
-            </div>
-            <div class="upper-message__date">
-              ${message.created_at}
-            </div>
-          </div>
-          <div class="lower-message">
-            <p class="lower-message__content">
-              ${message.content}
-            </p>
-          </div>
-          <img src=${message.image} >
-        </div>`
-      return html;
-    } else {
-      var html =
-       `<div class="message" data-message-id=${message.id}>
-          <div class="upper-message">
-            <div class="upper-message__user-name">
-              ${message.user_name}
-            </div>
-            <div class="upper-message__date">
-              ${message.created_at}
-            </div>
-          </div>
-          <div class="lower-message">
-            <p class="lower-message__content">
-              ${message.content}
-            </p>
-          </div>
-        </div>`
-      return html;
-    }
-  }
+
+  // function buildHTML(message){
+  //   if ( message.image ) {
+  //     var html =
+  //      `<div class="message" data-message-id=${message.id}>
+  //         <div class="upper-message">
+  //           <div class="upper-message__user-name">
+  //             ${message.user_name}
+  //           </div>
+  //           <div class="upper-message__date">
+  //             ${message.created_at}
+  //           </div>
+  //         </div>
+  //         <div class="lower-message">
+  //           <p class="lower-message__content">
+  //             ${message.content}
+  //           </p>
+  //         </div>
+  //         <img src=${message.image} >
+  //       </div>`
+  //     return html;
+  //   } else {
+  //     var html =
+  //      `<div class="message" data-message-id=${message.id}>
+  //         <div class="upper-message">
+  //           <div class="upper-message__user-name">
+  //             ${message.user_name}
+  //           </div>
+  //           <div class="upper-message__date">
+  //             ${message.created_at}
+  //           </div>
+  //         </div>
+  //         <div class="lower-message">
+  //           <p class="lower-message__content">
+  //             ${message.content}
+  //           </p>
+  //         </div>
+  //       </div>`
+  //     return html;
+  //   }
+  // }
+  var buildHTML = function(message) {
+    if (message.content && message.image) {
+      //data-idが反映されるようにしている
+      var html = `<div class="message" data-message-id=` + message.id + `>` +
+        `<div class="upper-message">` +
+          `<div class="upper-message__user-name">` +
+            message.user_name +
+          `</div>` +
+          `<div class="upper-message__date">` +
+            message.created_at +
+          `</div>` +
+        `</div>` +
+        `<div class="lower-message">` +
+          `<p class="lower-message__content">` +
+            message.content +
+          `</p>` +
+          `<img src="` + message.image + `" class="lower-message__image" >` +
+        `</div>` +
+      `</div>`
+    } else if (message.content) {
+      //同様に、data-idが反映されるようにしている
+      var html = `<div class="message" data-message-id=` + message.id + `>` +
+        `<div class="upper-message">` +
+          `<div class="upper-message__user-name">` +
+            message.user_name +
+          `</div>` +
+          `<div class="upper-message__date">` +
+            message.created_at +
+          `</div>` +
+        `</div>` +
+        `<div class="lower-message">` +
+          `<p class="lower-message__content">` +
+            message.content +
+          `</p>` +
+        `</div>` +
+      `</div>`
+    } else if (message.image) {
+      //同様に、data-idが反映されるようにしている
+      var html = `<div class="message" data-message-id=` + message.id + `>` +
+        `<div class="upper-message">` +
+          `<div class="upper-message__user-name">` +
+            message.user_name +
+          `</div>` +
+          `<div class="upper-message__date">` +
+            message.created_at +
+          `</div>` +
+        `</div>` +
+        `<div class="lower-message">` +
+          `<img src="` + message.image + `" class="lower-message__image" >` +
+        `</div>` +
+      `</div>`
+    };
+    return html;
+  };
 
   $('#new_message').on('submit', function(e){
     e.preventDefault();
@@ -61,6 +116,42 @@ $(function(){
     })
     .fail(function() {
       alert("メッセージ送信に失敗しました");
-  });
+    });
   })
+
+
+  var reloadMessages = function() {
+    //カスタムデータ属性を利用し、ブラウザに表示されている最新メッセージのidを取得
+    last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      //ルーティングで設定した通り/groups/id番号/api/messagesとなるよう文字列を書く
+      url: "api/messages",
+      //ルーティングで設定した通りhttpメソッドをgetに指定
+      type: 'get',
+      dataType: 'json',
+      //dataオプションでリクエストに値を含める
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        //追加するHTMLの入れ物を作る
+        var insertHTML = '';
+        //配列messagesの中身一つ一つを取り出し、HTMLに変換したものを入れ物に足し合わせる
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        //メッセージが入ったHTMLに、入れ物ごと追加
+        $('.messages').append(insertHTML);
+        $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+        $("#new_message")[0].reset();
+        $(".form__submit").prop("disabled", false);
+      }
+    })
+    .fail(function() {
+      console.log('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 })

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,45 +1,4 @@
 $(function(){
-
-  // function buildHTML(message){
-  //   if ( message.image ) {
-  //     var html =
-  //      `<div class="message" data-message-id=${message.id}>
-  //         <div class="upper-message">
-  //           <div class="upper-message__user-name">
-  //             ${message.user_name}
-  //           </div>
-  //           <div class="upper-message__date">
-  //             ${message.created_at}
-  //           </div>
-  //         </div>
-  //         <div class="lower-message">
-  //           <p class="lower-message__content">
-  //             ${message.content}
-  //           </p>
-  //         </div>
-  //         <img src=${message.image} >
-  //       </div>`
-  //     return html;
-  //   } else {
-  //     var html =
-  //      `<div class="message" data-message-id=${message.id}>
-  //         <div class="upper-message">
-  //           <div class="upper-message__user-name">
-  //             ${message.user_name}
-  //           </div>
-  //           <div class="upper-message__date">
-  //             ${message.created_at}
-  //           </div>
-  //         </div>
-  //         <div class="lower-message">
-  //           <p class="lower-message__content">
-  //             ${message.content}
-  //           </p>
-  //         </div>
-  //       </div>`
-  //     return html;
-  //   }
-  // }
   var buildHTML = function(message) {
     if (message.content && message.image) {
       //data-idが反映されるようにしている
@@ -148,7 +107,7 @@ $(function(){
       }
     })
     .fail(function() {
-      console.log('error');
+      alert("error")
     });
   };
   if (document.location.href.match(/\/groups\/\d+\/messages/)) {

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .upper-message
     .upper-message__user-name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#what
同じグループに属する他ユーザーがそのグループで投稿した際に、そのユーザーのブラウザと同様に、他ユーザーのブラウザにも更新無しで新しいメッセージを反映させます。

#why
チャットでやり取りする際に、同じグループに属するユーザーが投稿したメッセージを、いちいち更新して確認するのは手間です。そのために、更新無しで他ユーザーの投稿したメッセージが自動でブラウザに反映されるようにしました。

2画面で挙動を確認しました。
https://gyazo.com/c148120af60fc0a34fe15827148d53da

2画面のうち新しくログインした方からメッセージを投稿すると、上のgifのようにもう片方の画面にも反映されますが、逆の場合、メッセージを送信できず更新するともう片方のユーザーの画面になってしまいます。
現時点での挙動として正しいでしょうか？以下にリンクを貼ります。
https://gyazo.com/56ab69d8eaef99aeb41b902d8daba1aa

よろしくお願い致します。